### PR TITLE
Make the logos smaller

### DIFF
--- a/src/Signature/Signature.js
+++ b/src/Signature/Signature.js
@@ -50,7 +50,7 @@ const Signature = (props) => {
           color: 'black',
           fontFamily: 'Helvetica, Arial, sans-serif',
           fontSize: '11pt',
-          width: '400px',
+          width: 'auto',
         }}
       >
         <tbody>
@@ -155,44 +155,51 @@ const Signature = (props) => {
             </td>
           </tr>
           <tr>
-            <td
-              style={{
-                'vertical-align': 'middle',
-              }}
-            >
-              <img
-                width="250"
-                height="50"
-                style={{ width: '250px', height: '50px', maxWidth: 'none' }}
-                src={brandLogo.link}
-                alt={brandLogo.alt}
-              />
-            </td>
-            {addGPTW ? (
-              <td
-                style={{
-                  padding: 0,
-                }}
-              >
-                <table border="0" cellSpacing="0" cellPadding="0">
-                  <tr>
-                    <td>
+            <td>
+              <table border="0" cellSpacing="0" cellPadding="0">
+                <tr>
+                  <td
+                    style={{
+                      padding: 0,
+                      verticalAlign: 'middle',
+                    }}
+                  >
+                    <img
+                      width="150"
+                      height="30"
+                      style={{
+                        width: '150px',
+                        height: '30px',
+                        maxWidth: 'none',
+                      }}
+                      src={brandLogo.link}
+                      alt={brandLogo.alt}
+                    />
+                  </td>
+                  {addGPTW ? (
+                    <td
+                      style={{
+                        paddingLeft: '10px',
+                        paddingTop: 0,
+                        paddingBottom: 0,
+                      }}
+                    >
                       <img
-                        width="80"
-                        height="113"
+                        width="28"
+                        height="40"
                         style={{
-                          width: '80px',
-                          height: '113px',
+                          width: '28px',
+                          height: '40px',
                           maxWidth: 'none',
                         }}
                         src={brandInfo.brandGPTWLogo.link}
                         alt={brandInfo.brandGPTWLogo.alt}
                       />
                     </td>
-                  </tr>
-                </table>
-              </td>
-            ) : null}
+                  ) : null}
+                </tr>
+              </table>
+            </td>
           </tr>
           <tr>
             <tr>

--- a/src/Signature/Signature.js
+++ b/src/Signature/Signature.js
@@ -165,12 +165,13 @@ const Signature = (props) => {
                     }}
                   >
                     <img
-                      width="150"
-                      height="30"
+                      width="173"
+                      height="35"
                       style={{
-                        width: '150px',
-                        height: '30px',
+                        width: '173px',
+                        height: '35px',
                         maxWidth: 'none',
+                        verticalAlign: 'middle',
                       }}
                       src={brandLogo.link}
                       alt={brandLogo.alt}
@@ -185,12 +186,13 @@ const Signature = (props) => {
                       }}
                     >
                       <img
-                        width="28"
-                        height="40"
+                        width="62"
+                        height="62"
                         style={{
-                          width: '28px',
-                          height: '40px',
+                          width: '62px',
+                          height: '62px',
                           maxWidth: 'none',
+                          verticalAlign: 'middle',
                         }}
                         src={brandInfo.brandGPTWLogo.link}
                         alt={brandInfo.brandGPTWLogo.alt}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -2,15 +2,15 @@ const constants = {
   brandInfo: {
     brandName: 'MakerX',
     brandLink: 'https://makerx.com.au/',
-    brandLinkName: 'www.makerx.com.au',
+    brandLinkName: 'makerx.com.au',
     brandLinkColour: '#003FB5',
     brandLogo: {
       link: 'https://makerxsignatures.blob.core.windows.net/images/MakerX-Full-Logo-Black.jpg',
       alt: 'MakerX',
     },
     brandGPTWLogo: {
-      link: 'https://blog.makerx.com.au/content/images/size/w1000/2023/06/MakerX_2023_Certification_Badge-1.png',
-      alt: 'MakerX Great Place to Work',
+      link: 'https://makerxsignatures.blob.core.windows.net/images/GPTW-Best-Workplaces-2024.png',
+      alt: 'MakerX Best Workplaces',
     },
   },
 


### PR DESCRIPTION
Made the MakerX and GPTW logo a lot smaller. I updated how the table was defined to have both images be in a table row together instead of just the GPTW logo in a table itself.

![image](https://github.com/user-attachments/assets/b4e7e667-5e7d-4e74-86be-1e289c7a3d09)
