### PR TITLE
feat(gptw): update the logo url

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -9,7 +9,7 @@ const constants = {
       alt: 'MakerX',
     },
     brandGPTWLogo: {
-      link: 'https://makerxsignatures.blob.core.windows.net/images/GPTW-Best-Workplaces-current.png',
+      link: 'https://makerxsignatures.blob.core.windows.net/images/GPTW-Best-Workplaces-Current.png',
       alt: 'MakerX Best Workplaces',
     },
   },

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -9,7 +9,7 @@ const constants = {
       alt: 'MakerX',
     },
     brandGPTWLogo: {
-      link: 'https://makerxsignatures.blob.core.windows.net/images/GPTW-Best-Workplaces-2024.png',
+      link: 'https://makerxsignatures.blob.core.windows.net/images/GPTW-Best-Workplaces-current.png',
       alt: 'MakerX Best Workplaces',
     },
   },


### PR DESCRIPTION
This pull request updates the URL for the `brandGPTWLogo` image in the `src/constants/index.js` file to use a more generic "current" image rather than one specific to 2024. This ensures the logo remains up-to-date without needing yearly changes.

The old 2024 image has been updated, so people don't need to re-gen their sig

The new image [https://makerxsignatures.blob.core.windows.net/images/GPTW-Best-Workplaces-Current.png](https://makerxsignatures.blob.core.windows.net/images/GPTW-Best-Workplaces-Current.png) excludes the year